### PR TITLE
Update version string to 0.1.1

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -1,6 +1,6 @@
 import urllib, zipfile, tempfile, sys, os, threading, shutil
 def install():
-    tag='0.1.0'
+    tag='0.1.1'
 
     n=tempfile.NamedTemporaryFile(delete=False, suffix='.zip')
     n.close()

--- a/pkg/__init__.py
+++ b/pkg/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 import sys
 from commands import *


### PR DESCRIPTION
Some version string are still "0.1.0", which might cause some confusion :P
Also if user run the `installer.py` directly it will download the old version of idapkg