### PR TITLE
fix path to ida when load ida native version

### DIFF
--- a/pkg/env.py
+++ b/pkg/env.py
@@ -43,7 +43,7 @@ version_info = version_info_cls(0, 0, 0)
 
 
 def __load_ida_native_version():
-    sysdir = _os.path.dirname(_os.path.dirname(idaapi.__file__))
+    sysdir = _os.path.dirname(idaapi.idadir(idaapi.CFG_SUBDIR))
     exe_name = 'ida' if ea == 32 else 'ida64'
     if os == 'win':
         path = _os.path.join(sysdir, exe_name + '.exe')


### PR DESCRIPTION
as IDA pro 7.4 has both  python2 and python3 dir, it will get an error when use idapkg in IDA pro 7.4.